### PR TITLE
Refactor all model view logics to be inside `ModelViewer`

### DIFF
--- a/src/webapp/app/actions/CameraActions.js
+++ b/src/webapp/app/actions/CameraActions.js
@@ -1,0 +1,25 @@
+import {
+  CAMERA_PAN,
+  CAMERA_ROTATE,
+  CAMERA_ZOOM
+} from './types';
+
+export default {
+  pan: function() {
+    return {
+      type: CAMERA_PAN
+    };
+  },
+
+  rotate: function() {
+    return {
+      type: CAMERA_ROTATE
+    };
+  },
+
+  zoom: function() {
+    return {
+      type: CAMERA_ZOOM
+    };
+  }
+};

--- a/src/webapp/app/actions/index.js
+++ b/src/webapp/app/actions/index.js
@@ -1,4 +1,5 @@
 export default {
   RequestActions: require('./RequestActions'),
-  RenderActions: require('./RenderActions')
+  RenderActions: require('./RenderActions'),
+  CameraActions: require('./CameraActions')
 };

--- a/src/webapp/app/actions/types/CameraActionTypes.js
+++ b/src/webapp/app/actions/types/CameraActionTypes.js
@@ -1,0 +1,15 @@
+import TypeHelper from './TypeHelper';
+
+// Normal Action Types
+const normalTypes = {
+  CAMERA_PAN: null,
+  CAMERA_ROTATE: null,
+  CAMERA_ZOOM: null
+};
+
+// Promise Action Types
+const promiseTypes = {
+
+};
+
+export default TypeHelper.combineTypes(normalTypes, promiseTypes);

--- a/src/webapp/app/actions/types/index.js
+++ b/src/webapp/app/actions/types/index.js
@@ -1,7 +1,5 @@
-import RequestActionTypes from './RequestActionTypes';
-import RenderActionTypes from './RenderActionTypes';
-
 export default {
-  ...RequestActionTypes,
-  ...RenderActionTypes
+  ...require('./RequestActionTypes'),
+  ...require('./RenderActionTypes'),
+  ...require('./CameraActionTypes')
 };

--- a/src/webapp/app/components/_containers/ModelContainer.js
+++ b/src/webapp/app/components/_containers/ModelContainer.js
@@ -1,26 +1,16 @@
 import React from 'react';
 import {connect} from 'react-redux';
 
-import {ModelCanvas} from '../render';
-import {RenderActions} from 'webapp/app/actions';
+import {ModelViewer} from '../model';
 
 const CLASS_NAME = 'cb-ctn-model';
 
 class ModelContainer extends React.Component {
   static propTypes = {
-    isShowingWireframe: React.PropTypes.bool,
-    params: React.PropTypes.object,
-    dispatch: React.PropTypes.func.isRequired
-  }
 
-  _onToggleWireframeButtonClick = () => {
-    const {dispatch} = this.props;
-    dispatch(RenderActions.toggleWireframe());
   }
 
   render() {
-    const {isShowingWireframe} = this.props;
-
     return (
       <div className={CLASS_NAME}>
         <h2 className={`${CLASS_NAME}-title`}>
@@ -28,10 +18,7 @@ class ModelContainer extends React.Component {
         </h2>
         <div className="row">
           <div className="col-md-8">
-            <ModelCanvas showWireframe={isShowingWireframe} />
-            <button type="button" className="btn btn-success" onClick={this._onToggleWireframeButtonClick}>
-              Toggle Wireframe
-            </button>
+            <ModelViewer />
           </div>
           <div className="col-md-4">
             <div className={`${CLASS_NAME}-info-bar`}>
@@ -43,11 +30,8 @@ class ModelContainer extends React.Component {
   }
 }
 
-export default ModelContainer;
-
-
-export default connect((state) => {
+export default connect(() => {
   return {
-    isShowingWireframe: state.RenderStore.get('isShowingWireframe')
+
   };
 })(ModelContainer);

--- a/src/webapp/app/components/model/ModelViewer.js
+++ b/src/webapp/app/components/model/ModelViewer.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import {connect} from 'react-redux';
+
+import {ModelCanvas} from '../render';
+import {RenderActions} from 'webapp/app/actions';
+
+const CLASS_NAME = 'cb-model-viewer';
+
+/**
+ * Main Model Viewer to interact with model
+ */
+class ModelViewer extends React.Component {
+  static propTypes = {
+    showWireframe: React.PropTypes.bool,
+    dispatch: React.PropTypes.func.isRequired
+  }
+
+  _onToggleWireframeButtonClick = () => {
+    const {dispatch} = this.props;
+    dispatch(RenderActions.toggleWireframe());
+  }
+
+  render() {
+    const {showWireframe} = this.props;
+
+    return (
+      <div className={CLASS_NAME}>
+        <ModelCanvas showWireframe={showWireframe} />
+        <button type="button"
+          className="btn btn-success"
+          onClick={this._onToggleWireframeButtonClick}>
+          Toggle Wireframe
+        </button>
+      </div>
+    );
+  }
+}
+
+export default connect((state) => {
+  return {
+    showWireframe: state.RenderStore.get('showWireframe')
+  };
+})(ModelViewer);

--- a/src/webapp/app/components/model/index.js
+++ b/src/webapp/app/components/model/index.js
@@ -1,3 +1,4 @@
 export default {
-  ModelCard: require('./ModelCard')
+  ModelCard: require('./ModelCard'),
+  ModelViewer: require('./ModelViewer')
 };

--- a/src/webapp/app/components/render/ModelCanvas.js
+++ b/src/webapp/app/components/render/ModelCanvas.js
@@ -63,7 +63,7 @@ class ModelCanvas extends React.Component {
       aspect: aspectRatio,
       near: 1,
       far: 5000,
-      position: new Vector3(50, 0, 200),
+      position: new Vector3(0, 0, 300),
       lookat: new Vector3(0, 0, 0)
     };
 

--- a/src/webapp/app/reducers/CameraReducer.js
+++ b/src/webapp/app/reducers/CameraReducer.js
@@ -2,18 +2,30 @@ import Immutable from 'immutable';
 
 import ReducerHelper from './ReducerHelper';
 import {
-  WIREFRAME_TOGGLE
+  CAMERA_PAN,
+  CAMERA_ROTATE,
+  CAMERA_ZOOM
 } from 'webapp/app/actions/types';
 
 const initialState = Immutable.fromJS({
-  showWireframe: false
+  posX: 0,
+  posY: 0,
+  posZ: 300,
+  lookX: 0,
+  lookY: 0,
+  lookZ: 0
 });
 
 export default ReducerHelper.createReducer(initialState, {
-  [WIREFRAME_TOGGLE]: (state) => {
-    let nextState = state;
-    nextState = nextState.set('showWireframe', !nextState.get('showWireframe'));
+  [CAMERA_PAN]: function() {
 
-    return nextState;
+  },
+
+  [CAMERA_ROTATE]: function() {
+
+  },
+
+  [CAMERA_ZOOM]: function() {
+
   }
 });

--- a/src/webapp/app/reducers/index.js
+++ b/src/webapp/app/reducers/index.js
@@ -2,10 +2,12 @@ import {routerStateReducer} from 'redux-router';
 
 import RequestStore from './RequestReducer';
 import RenderStore from './RenderReducer';
+import CameraStore from './CameraReducer';
 
 // Define list of Redux stores
 export default {
   router: routerStateReducer,
   RequestStore,
-  RenderStore
+  RenderStore,
+  CameraStore
 };


### PR DESCRIPTION
As title, this refactor all model viewing logic to be inside `ModelViewer` component instead of `ModelContainer`
