### PR TITLE
[Fix] Fixed view resetting on auto-rotate

### DIFF
--- a/src/webapp/render/ModelScene.js
+++ b/src/webapp/render/ModelScene.js
@@ -166,6 +166,7 @@ class ModelScene {
     Object.assign(this.cameraState, state);
     this.controls.resetView = this.cameraState.resetView;
     this.controls.autoRotate = this.cameraState.autoRotate;
+    this.cameraState.resetView = false;
   }
 
   /**


### PR DESCRIPTION
Reset camerstate's resetView to false after assigning to OrbitControls
