### PR TITLE
[fix] Reset button status in store on mounting of ModelViewer component

### DIFF
--- a/src/webapp/actions/RenderActions.js
+++ b/src/webapp/actions/RenderActions.js
@@ -4,10 +4,17 @@ import {
   AUTO_ROTATE_TOGGLE,
   RESET_VIEW_TOGGLE,
   PLAY_WALKTHROUGH,
-  TEXTURE_TOGGLE
+  TEXTURE_TOGGLE,
+  RESET_BUTTONS
 } from './types';
 
 export default {
+  resetButtons() {
+    return {
+      type: RESET_BUTTONS
+    };
+  },
+
   toggleWireframe() {
     return {
       type: WIREFRAME_TOGGLE

--- a/src/webapp/actions/types/RenderActionTypes.js
+++ b/src/webapp/actions/types/RenderActionTypes.js
@@ -7,7 +7,8 @@ const normalTypes = {
   AUTO_ROTATE_TOGGLE: null,
   RESET_VIEW_TOGGLE: null,
   PLAY_WALKTHROUGH: null,
-  TEXTURE_TOGGLE: null
+  TEXTURE_TOGGLE: null,
+  RESET_BUTTONS: null
 };
 
 // Promise Action Types

--- a/src/webapp/components/model/ModelViewer.js
+++ b/src/webapp/components/model/ModelViewer.js
@@ -21,6 +21,11 @@ class ModelViewer extends React.Component {
     walkthroughPoints: React.PropTypes.instanceOf(Immutable.List)
   };
 
+  componentDidMount() {
+    const { dispatch } = this.props;
+    dispatch(RenderActions.resetButtons());
+  }
+
   _onToggleWireframeButtonClick = () => {
     const { dispatch } = this.props;
     dispatch(RenderActions.toggleWireframe());

--- a/src/webapp/reducers/RenderReducer.js
+++ b/src/webapp/reducers/RenderReducer.js
@@ -7,7 +7,8 @@ import {
   AUTO_ROTATE_TOGGLE,
   RESET_VIEW_TOGGLE,
   PLAY_WALKTHROUGH,
-  TEXTURE_TOGGLE
+  TEXTURE_TOGGLE,
+  RESET_BUTTONS
 } from 'webapp/actions/types';
 
 const initialState = Immutable.fromJS({
@@ -20,6 +21,17 @@ const initialState = Immutable.fromJS({
 });
 
 export default ReducerHelper.createReducer(initialState, {
+  [RESET_BUTTONS]: (state) => {
+    let nextState = state;
+    nextState = nextState.set('wireframe', false);
+    nextState = nextState.set('shadingMode', 0);
+    nextState = nextState.set('autoRotate', false);
+    nextState = nextState.set('resetViewToggle', false);
+    nextState = nextState.set('playbackWalkthroughToggle', false);
+
+    return nextState;
+  },
+
   [WIREFRAME_TOGGLE]: (state) => {
     let nextState = state;
     nextState = nextState.set('wireframe', !nextState.get('wireframe'));

--- a/tests/webapp/reducers/RenderReducer.spec.js
+++ b/tests/webapp/reducers/RenderReducer.spec.js
@@ -23,13 +23,12 @@ describe('Render Reducer', () => {
   });
   describe('#Action: RESET_BUTTONS', () => {
     it('Should return the initial state', () => {
-      expect(reducer(undefined, { type: RESET_BUTTONS })).to.equal(Map({
+      expect(reducer({}, { type: RESET_BUTTONS })).to.equal(Map({
         wireframe: false,
         shadingMode: 0,
         autoRotate: false,
         resetViewToggle: false,
-        playbackWalkthroughToggle: false,
-        resizedTexture: false
+        playbackWalkthroughToggle: false
       }));
     });
   });

--- a/tests/webapp/reducers/RenderReducer.spec.js
+++ b/tests/webapp/reducers/RenderReducer.spec.js
@@ -6,7 +6,8 @@ import {
   WIREFRAME_TOGGLE,
   AUTO_ROTATE_TOGGLE,
   SHADING_TOGGLE,
-  TEXTURE_TOGGLE
+  TEXTURE_TOGGLE,
+  RESET_BUTTONS
 } from 'webapp/actions/types';
 
 describe('Render Reducer', () => {
@@ -19,6 +20,26 @@ describe('Render Reducer', () => {
       playbackWalkthroughToggle: false,
       resizedTexture: false
     }));
+  });
+  describe('#Action: RESET_BUTTONS', () => {
+    it('Should return the initial state', () => {
+      expect(reducer(undefined, { type: RESET_BUTTONS })).to.equal(Map({
+        wireframe: false,
+        shadingMode: 0,
+        autoRotate: false,
+        resetViewToggle: false,
+        playbackWalkthroughToggle: false,
+        resizedTexture: false
+      }));
+    });
+
+    it('Should handle WIREFRAME_TOGGLE toggling from FALSE to TRUE', () => {
+      expect(
+        reducer(Map({ wireframe: false }), { type: WIREFRAME_TOGGLE })
+      ).to.equal(
+        Map({ wireframe: true })
+      );
+    });
   });
 
   describe('#Action: WIREFRAME_TOGGLE', () => {

--- a/tests/webapp/reducers/RenderReducer.spec.js
+++ b/tests/webapp/reducers/RenderReducer.spec.js
@@ -32,14 +32,6 @@ describe('Render Reducer', () => {
         resizedTexture: false
       }));
     });
-
-    it('Should handle WIREFRAME_TOGGLE toggling from FALSE to TRUE', () => {
-      expect(
-        reducer(Map({ wireframe: false }), { type: WIREFRAME_TOGGLE })
-      ).to.equal(
-        Map({ wireframe: true })
-      );
-    });
   });
 
   describe('#Action: WIREFRAME_TOGGLE', () => {


### PR DESCRIPTION
Fixed issue where button status persisted when opening different models 
