### PR TITLE
[fix] Added double-side attribute to smooth/flat shaded mode meshes

### DIFF
--- a/src/webapp/render/ModelScene.js
+++ b/src/webapp/render/ModelScene.js
@@ -600,7 +600,8 @@ class ModelScene {
             color: 0xc0c0c0,
             shading: THREE.SmoothShading,
             wireframe: false,
-            transparent: true
+            transparent: true,
+            side: THREE.DoubleSide
           }));
           objects.push(newMesh);
         }
@@ -614,7 +615,8 @@ class ModelScene {
             color: 0xc0c0c0,
             shading: THREE.FlatShading,
             wireframe: false,
-            transparent: true
+            transparent: true,
+            side: THREE.DoubleSide
           }));
           objects.push(newMesh);
         }


### PR DESCRIPTION
Small fix to meshes when rendering in flat or smooth shading
